### PR TITLE
Always add __typename to abstract types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 .vscode
 .history
 .idea
+.DS_Store
 coverage.out

--- a/plan.go
+++ b/plan.go
@@ -174,9 +174,6 @@ func extractSelectionSet(ctx *PlanningContext, insertionPoint []string, parentTy
 			if err != nil {
 				return nil, nil, err
 			}
-			if !selectionSetHasFieldNamed(selectionSet, "__typename") {
-				selectionSet = append(selectionSet, &ast.Field{Alias: "__typename", Name: "__typename", Definition: &ast.FieldDefinition{Name: "__typename", Type: ast.NamedType("String", nil)}})
-			}
 			inlineFragment := *selection
 			inlineFragment.SelectionSet = selectionSet
 			selectionSetResult = append(selectionSetResult, &inlineFragment)
@@ -192,9 +189,6 @@ func extractSelectionSet(ctx *PlanningContext, insertionPoint []string, parentTy
 			)
 			if err != nil {
 				return nil, nil, err
-			}
-			if !selectionSetHasFieldNamed(selectionSet, "__typename") {
-				selectionSet = append(selectionSet, &ast.Field{Alias: "__typename", Name: "__typename", Definition: &ast.FieldDefinition{Name: "__typename", Type: ast.NamedType("String", nil)}})
 			}
 			inlineFragment := ast.InlineFragment{
 				TypeCondition: selection.Definition.TypeCondition,
@@ -262,6 +256,11 @@ func extractSelectionSet(ctx *PlanningContext, insertionPoint []string, parentTy
 				break
 			}
 		}
+		selectionSetResult = append(selectionSetResult, &ast.Field{
+			Alias: "__typename",
+			Name: "__typename",
+			Definition: &ast.FieldDefinition{Name: "__typename", Type: ast.NamedType("String", nil)},
+		})
 	// Otherwise, add an id selection to boundary types where the result
 	// will be merged with another step (i.e.: has children or is a child step).
 	} else if parentType != queryObjectName &&

--- a/plan_test.go
+++ b/plan_test.go
@@ -264,7 +264,7 @@ func TestQueryPlanInlineFragment(t *testing.T) {
 			{
 				"ServiceURL": "A",
 				"ParentType": "Query",
-				"SelectionSet": "{ movies { ... on Movie { id title(language: French) __typename } } }",
+				"SelectionSet": "{ movies { ... on Movie { id title(language: French) } } }",
 				"InsertionPoint": null,
 				"Then": null
 			}
@@ -314,7 +314,7 @@ func TestQueryPlanInlineFragmentPlan(t *testing.T) {
 			{
 				"ServiceURL": "A",
 				"ParentType": "Query",
-				"SelectionSet": "{ movies { _id: id ... on Movie { id title(language: French) __typename } } }",
+				"SelectionSet": "{ movies { _id: id ... on Movie { id title(language: French) } } }",
 				"InsertionPoint": null,
 				"Then": [
 					{
@@ -347,7 +347,7 @@ func TestQueryPlanFragmentSpread1(t *testing.T) {
 			{
 				"ServiceURL": "A",
 				"ParentType": "Query",
-				"SelectionSet": "{ movies { ... on Movie { id title(language: French) __typename } } }",
+				"SelectionSet": "{ movies { ... on Movie { id title(language: French) } } }",
 				"InsertionPoint": null,
 				"Then": null
 			}
@@ -496,6 +496,7 @@ func TestQueryPlanExpandAbstractTypesWithPossibleBoundaryIds(t *testing.T) {
 		"name",
 		"... on Lion { _id: id }",
 		"... on Snake { _id: id }",
+		"__typename",
 	}
 	PlanTestFixture3.CheckUnorderedRootFieldSelections(t, query, rootFieldSelections)
 }
@@ -517,8 +518,9 @@ func TestQueryPlanInlineFragmentSpreadOfInterface(t *testing.T) {
 		"name",
 		"... on Lion { _id: id }",
 		"... on Snake { _id: id }",
-		"... on Lion { maneColor __typename }",
-		"... on Snake { _id: id __typename }",
+		"... on Lion { maneColor }",
+		"... on Snake { _id: id }",
+		"__typename",
 	}
 	PlanTestFixture3.CheckUnorderedRootFieldSelections(t, query, rootFieldSelections)
 }
@@ -632,13 +634,13 @@ func TestQueryPlanSupportsAliasing(t *testing.T) {
 }
 
 func TestQueryPlanSupportsUnions(t *testing.T) {
-	PlanTestFixture4.Check(t, "{ animals { ... on Dog { name } ... on Cat { name }  ... on Snake { name } } }", `
+	PlanTestFixture4.Check(t, "{ animals { ... on Dog { name } ... on Cat { name } ... on Snake { name } } }", `
     {
       "RootSteps": [
         {
           "ServiceURL": "A",
           "ParentType": "Query",
-          "SelectionSet": "{ animals { ... on Dog { name __typename } ... on Cat { name __typename } ... on Snake { name __typename } } }",
+          "SelectionSet": "{ animals { ... on Dog { name } ... on Cat { name } ... on Snake { name } __typename } }",
           "InsertionPoint": null,
           "Then": null
         }


### PR DESCRIPTION
Preemptively fixing the same issue described in https://github.com/movio/bramble/pull/81, but with `__typename`.

Given that the merge resolver uses `__typename` while assembling abstract types, we need to assure that the field is always returned. However, the automated `__typename` hint is only added to user-defined fragments, which aren't guaranteed to be present when making abstract type selections (case of point: selecting base interface fields).

While I haven't actually made this scenario fail yet, I strongly suspect it can be broken...